### PR TITLE
[DEPLOY] rowi1de/graphql-reactive 0.1.17 by Robert Wiesner (robert.wiesner@reev.com)

### DIFF
--- a/services/graphql-reactive.yaml
+++ b/services/graphql-reactive.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   source:
     repoURL: ghcr.io/rowi1de/graphql-reactive
-    targetRevision: 0.1.16
+    targetRevision: 0.1.17
     chart: graphql-reactive
   project: services
   destination:


### PR DESCRIPTION
- Commit https://github.com/rowi1de/graphql-reactive/commit/1ac3111d973a09ad02f0dcd72854b805d8121468
- Message: Automated trigger  by rowi1de : Add schema printer
- Author: @rowi1de -- Robert Wiesner (robert.wiesner@reev.com)
- Actor: @rowi1de
- Release https://github.com/rowi1de/graphql-reactive/releases/tag/0.1.17
---
## What's Changed
* Bump actions/setup-java from 3.7.0 to 3.8.0 by @dependabot in https://github.com/rowi1de/graphql-reactive/pull/141
* Bump azure/setup-helm from 3.4 to 3.5 by @dependabot in https://github.com/rowi1de/graphql-reactive/pull/142
* Bump ncipollo/release-action from 1.11.2 to 1.12.0 by @dependabot in https://github.com/rowi1de/graphql-reactive/pull/143
* Bump helm/kind-action from 1.4.0 to 1.5.0 by @dependabot in https://github.com/rowi1de/graphql-reactive/pull/144
* Bump actions/setup-java from 3.8.0 to 3.9.0 by @dependabot in https://github.com/rowi1de/graphql-reactive/pull/145
* Bump springdoc-openapi-kotlin from 1.6.13 to 1.6.14 by @dependabot in https://github.com/rowi1de/graphql-reactive/pull/147
* Bump springdoc-openapi-webflux-ui from 1.6.13 to 1.6.14 by @dependabot in https://github.com/rowi1de/graphql-reactive/pull/146
* Bump org.springframework.boot from 3.0.0 to 3.0.1 by @dependabot in https://github.com/rowi1de/graphql-reactive/pull/148
* Bump actions/upload-artifact from 3.1.1 to 3.1.2 by @dependabot in https://github.com/rowi1de/graphql-reactive/pull/152


**Full Changelog**: https://github.com/rowi1de/graphql-reactive/compare/0.1.16...0.1.17