### PR TITLE
[DEPLOY] rowi1de/graphql-reactive 0.1.18 by Robert Wiesner (robert.wiesner@reev.com)

### DIFF
--- a/services/graphql-reactive.yaml
+++ b/services/graphql-reactive.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   source:
     repoURL: ghcr.io/rowi1de/graphql-reactive
-    targetRevision: 0.1.17
+    targetRevision: 0.1.18
     chart: graphql-reactive
   project: services
   destination:


### PR DESCRIPTION
- Commit https://github.com/rowi1de/graphql-reactive/commit/26b6c22be51dbcfcd45721c3e0b178b308b00394
- Message: Automated trigger  by rowi1de : Hint about spring-graphql
- Author: @rowi1de -- Robert Wiesner (robert.wiesner@reev.com)
- Actor: @rowi1de
- Release https://github.com/rowi1de/graphql-reactive/releases/tag/0.1.18
---
## What's Changed
* Bump org.springframework.boot from 3.0.1 to 3.0.2 by @dependabot in https://github.com/rowi1de/graphql-reactive/pull/153


**Full Changelog**: https://github.com/rowi1de/graphql-reactive/compare/0.1.17...0.1.18